### PR TITLE
save link and open in new tab

### DIFF
--- a/portal-app/src/App.js
+++ b/portal-app/src/App.js
@@ -6,6 +6,7 @@ import "./index.css";
 import { EditContent } from "./pages/edit_content";
 import Home from "./pages/home";
 import { UploadContent } from "./pages/upload-content";
+import ViewContent  from "./pages/view-content";
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/upload-content" element={<UploadContent />} />
         <Route path="/edit-content/:id" element={<EditContent />} />
+        <Route path="/view-content/:UnitID" element={<ViewContent />} />
       </Routes>
     </BrowserRouter>
   );

--- a/portal-app/src/components/Overlay.jsx
+++ b/portal-app/src/components/Overlay.jsx
@@ -7,8 +7,15 @@ const Overlay = ({ content, onClose }) => {
   const [showOptions, setShowOptions] = useState(false);
   if (!content) return null;
 
+  const handleSaveLink = () => {
+    const url = `${window.location.origin}/view-content/${content.UnitID}`;
+    navigator.clipboard.writeText(url).then(() => {
+      alert("Link saved to clipboard!");
+    });
+  };
+
   return (
-    <div className="fixed bottom-0 right-0 bg-white p-4 border shadow=lg w-2/3 h-4/5 z-50">
+    <div className="fixed bottom-0 right-0 bg-white p-4 border shadow-lg w-2/3 h-4/5 z-50">
       <div className="flex justify-between items-center">
         <h2 className="text-4xl font-bold">{content.Title}</h2>
         <div className="flex space-x-2">
@@ -22,14 +29,14 @@ const Overlay = ({ content, onClose }) => {
             {showOptions && (
               <div className="absolute right-0 bg-white border shadow-md mt-2 rounded w-48">
                 <button
-                  onClick={() => alert("Open in New Tab")}
+                  onClick={() => window.open(`/view-content/${content.UnitID}`, '_blank')}
                   className="block px-4 py-2"
                 >
                   Open in New Tab
                 </button>
                 <hr />
                 <button
-                  onClick={() => alert("Save the Link")}
+                  onClick={handleSaveLink}
                   className="block px-4 py-2"
                 >
                   Save the Link

--- a/portal-app/src/pages/view-content/index.jsx
+++ b/portal-app/src/pages/view-content/index.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+const ViewContent = () => {
+  const { UnitID } = useParams(); // Get UnitID from the URL
+  const [content, setContent] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    // Fetch all units to map UnitID to id
+    fetch(`http://localhost:3001/api/units`) // Fetch all units to get mapping of UnitID to id
+      .then((response) => response.json())
+      .then((units) => {
+        // Find the unit with the matching UnitID
+        const unit = units.find((unit) => unit.UnitID === UnitID);
+        if (unit) {
+          // Now fetch the content using the id
+          return fetch(`http://localhost:3001/api/unit/${unit.id}`);
+        } else {
+          throw new Error("Unit not found");
+        }
+      })
+      .then((response) => response.json())
+      .then((data) => setContent(data))
+      .catch((error) => {
+        console.error('Error fetching content:', error);
+        setError(error.message);
+      });
+  }, [UnitID]);
+
+  if (error) return <div>{error}</div>;
+  if (!content) return <div>Loading...</div>;
+
+  return (
+    <div className="p-8">
+      <h1 className="text-4xl font-bold">{content.Title}</h1>
+      <p>Category: {content.Category}</p>
+      <p>Type: {content.Type}</p>
+      <p>Level: {content.Level}</p>
+      <p>Duration: {content.Duration}</p>
+      <div className="mt-4 p-3 border rounded">
+        <div className="text-left">{content.Abstract}</div>
+      </div>
+    </div>
+  );
+};
+
+export default ViewContent;


### PR DESCRIPTION
'Save Link' and 'Open in new tab' buttons on the expanded view are functional. Save link copies the link to the clipboard. Can be pasted in a new window to test. The link takes the user to the page for the unit. We can change this. For now the page displays basic info about the unit with no styling. 