### PR TITLE
Fix item filter

### DIFF
--- a/portal-app/src/components/ListView.jsx
+++ b/portal-app/src/components/ListView.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import TileItem from "./TileItem";
 import Overlay from "./Overlay";
 
@@ -32,7 +31,7 @@ const ListView = ({ content }) => {
   const [selectedType, setSelectedType] = useState("");
   const [selectedLevel, setSelectedLevel] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
-  const [itemsPerPage, setItemsPerPage] = useState(10);
+  const [itemsPerPage, setItemsPerPage] = useState(12);
   const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
@@ -90,7 +89,6 @@ const ListView = ({ content }) => {
     setSelectedContent(contentItem);
   };
 
-  const navigate = useNavigate();
   return (
     <div className="text-center mt-10">
       <h2 className="text-2xl font-bold">


### PR DESCRIPTION
1. Fix the mismatch between tile item type in web page and firestore data. Now the type is Lectures. I also updated the inconsistent data from previous version in firebase.
2. Adjust the number of the tile items per page, now it looks better from devices of different sizes.
