### PR TITLE
[Issue #103] Fix the display bugs in frontend

### DIFF
--- a/portal-app/src/pages/view-content/index.jsx
+++ b/portal-app/src/pages/view-content/index.jsx
@@ -1,12 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { storage } from "../../firebase/firebaseConfig";
-import { ref, getDownloadURL } from "firebase/storage";
 
 const ViewContent = () => {
   const { UnitID } = useParams(); // Get UnitID from the URL
   const [content, setContent] = useState(null);
-  const [fileUrl, setFileUrl] = useState(null);
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -22,13 +19,6 @@ const ViewContent = () => {
           );
           const data = await contentResponse.json();
           setContent(data);
-
-          if (unit.fileUrl) {
-            const fileRef = ref(storage, unit.fileUrl);
-            const downloadURL = await getDownloadURL(fileRef);
-            console.log(downloadURL);
-            setFileUrl(downloadURL);
-          }
         } else {
           throw new Error("Unit not found");
         }
@@ -66,18 +56,18 @@ const ViewContent = () => {
       <div className="mt-6 p-4 border rounded-lg bg-gray-50">
         <div className="text-left text-gray-800">{content.Abstract}</div>
       </div>
-      {fileUrl && (
+      {content.fileUrl && (
         <div className="mt-6">
           <h2 className="text-2xl font-semibold text-gray-900 mb-2">
-            File Preview
+            Content Preview
           </h2>
           <a
-            href={fileUrl}
+            href={content.fileUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-blue-600 underline"
           >
-            Open File
+            Click to Open File
           </a>
         </div>
       )}


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #103 

## Description
- [x] Each nugget should have an associated web page to it. Clicking a nugget should take to a HTML page that can be made public and accessible without logging into the product.
- [x] The HTML page corresponding the nugget displays the content as is. If there is a link, it shows the link. Clicking the link will open it in a separate tab.
- [x] The test vedio (https://vimeo.com/1046278793) can be viewed when user click the content link

## Type of Change
- [x] Bug fix

## Checklist: All checked

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/94147a08-b985-4237-9685-f56a18ea2f6f)

## Additional Context

