### PR TITLE
[Issue #134] Add button on lesson generator page

### DIFF
--- a/portal-app/src/components/OverlayTileView.jsx
+++ b/portal-app/src/components/OverlayTileView.jsx
@@ -159,7 +159,7 @@ const OverlayTileView = ({ content, onClose, onSelectMaterial }) => {
                       level={item.Level}
                       duration={item.Duration}
                       date={formatDate(item.LastModified)}
-                      onClick={() => onSelectMaterial(item)}
+                      onClick={() => {}} //do not need this function in this page
                       onSelect={(id) => {
                         setSelectedTiles((prevState) => ({
                           ...prevState,
@@ -192,23 +192,33 @@ const OverlayTileView = ({ content, onClose, onSelectMaterial }) => {
           </div>
 
           <div className="flex justify-between items-center mt-4">
-            <button
-              onClick={() => handlePageChange("prev")}
-              disabled={currentPage === 1}
-              className="p-2 bg-gray-300 rounded"
-            >
-              Prev
-            </button>
-            <span className="p-2">Page {currentPage}</span>
-            <button
-              onClick={() => handlePageChange("next")}
-              disabled={
-                currentPage === Math.ceil(filteredContent.length / itemsPerPage)
-              }
-              className="p-2 bg-gray-300 rounded"
-            >
-              Next
-            </button>
+            <div className="w-1/2 flex justify-between items-center">
+              <button
+                onClick={() => handlePageChange("prev")}
+                disabled={currentPage === 1}
+                className="p-2 bg-gray-300 rounded"
+              >
+                Prev
+              </button>
+              <span className="p-2">Page {currentPage}</span>
+              <button
+                onClick={() => handlePageChange("next")}
+                disabled={
+                  currentPage === Math.ceil(filteredContent.length / itemsPerPage)
+                }
+                className="p-2 bg-gray-300 rounded"
+              >
+                Next
+              </button>
+            </div>
+            <div className="flex justify-end">
+              <button
+                onClick={onClose}
+                className="text-lg bg-blue-500 text-white py-1 px-4 rounded-md hover:bg-blue-700 transition duration-200"
+              >
+                Save
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/portal-app/src/components/OverlayTileView.jsx
+++ b/portal-app/src/components/OverlayTileView.jsx
@@ -24,7 +24,7 @@ const types = [
 
 const levels = ["Basic", "Intermediate", "Advanced"];
 
-const OverlayTileView = ({ content, onClose, onSelectMaterial }) => {
+const OverlayTileView = ({ content, onClose, onSelectMaterial, initialSelectedTiles = {} }) => {
   const [filteredContent, setFilteredContent] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState("");
   const [selectedType, setSelectedType] = useState("");
@@ -32,7 +32,7 @@ const OverlayTileView = ({ content, onClose, onSelectMaterial }) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 6;
-  const [selectedTiles, setSelectedTiles] = useState({});
+  const [selectedTiles, setSelectedTiles] = useState(initialSelectedTiles|| []);
 
   useEffect(() => {
     setFilteredContent(content);
@@ -166,24 +166,25 @@ const OverlayTileView = ({ content, onClose, onSelectMaterial }) => {
                           [id]: !prevState[id],
                         }));
                       }}
-                      isSelected={selectedTiles[item.id] || false}
+                      isSelected={Array.isArray(selectedTiles) && selectedTiles.includes(item.id)}
                       isLessonGenerator={true}
                     />
                     <button
                       onClick={() => {
-                        setSelectedTiles((prevState) => ({
-                          ...prevState,
-                          [item.id]: !selectedTiles[item.id],
-                        }));
+                        setSelectedTiles((prevState) =>
+                          prevState.includes(item.id)
+                            ? prevState.filter((id) => id !== item.id)
+                            : [...prevState, item.id]
+                        );
                         onSelectMaterial(item);
                       }}
                       className={`absolute bottom-3 right-2 py-1 px-3 rounded ${
-                        selectedTiles[item.id]
+                        Array.isArray(selectedTiles) && selectedTiles.includes(item.id)
                           ? "bg-red-500 text-white"
                           : "bg-blue-500 text-white"
                       }`}
                     >
-                      {selectedTiles[item.id] ? "Unselect" : "Select"}
+                      {Array.isArray(selectedTiles) && selectedTiles.includes(item.id) ? "Unselect" : "Select"}
                     </button>
                   </div>
                 );

--- a/portal-app/src/pages/lesson_generator/index.jsx
+++ b/portal-app/src/pages/lesson_generator/index.jsx
@@ -430,6 +430,7 @@ export const LessonGenerator = () => {
             content={portalContent}
             onClose={() => setShowOverlay(false)}
             onSelectMaterial={onSelectMaterial}
+            initialSelectedTiles={Object.values(selectedMaterials || {}).flat().map((item) => item.id)}            
           />
         )}
         <Modal


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #134 

## Description
- [x] Add a Save button to save nugget selection on lesson generator page.
- [x] Disable duplicate selection for nuggets in OverlayTileView .
- [x] Fix the data structure mismatch between pages and OverlayTileView component.
- [x] Nuggets remain selected when close window and openup again.

## Type of Change
- [x] Bug fix

## Checklist: All checked

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/f25c9797-f119-4c57-97ae-4415a9f812ce)
![image](https://github.com/user-attachments/assets/6f5dedbb-d67b-466d-84a9-b58a70e8a790)

## Additional Context
- Add a new prop `initialSelectedTiles` for OverlayTileView to show the already selected  nuggets
- `initialSelectedTiles` should be array of 'contentId'

