### PR TITLE
[Issue #168] make delete and checkbox delete only work for admin

### DIFF
--- a/portal-app/src/components/ListView.jsx
+++ b/portal-app/src/components/ListView.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import TileItem from "./TileItem";
 import Overlay from "./Overlay";
-import { getAuth } from "firebase/auth";
+import useUserData from "../hooks/useUserData";
 
 const categories = [
   "Python", // New Category
@@ -33,6 +33,7 @@ const ListView = ({ content }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedItems, setSelectedItems] = useState(new Set());
   const [deleteError, setDeleteError] = useState("");
+  const { user, userData } = useUserData();
 
   const filterContent = useCallback(() => {
     let filtered = content;
@@ -96,8 +97,6 @@ const ListView = ({ content }) => {
 
   const handleDeleteUnit = async (id) => {
     try {
-      const auth = getAuth();
-      const user = auth.currentUser;
       if (!user) {
         throw new Error("User not authenticated");
       }
@@ -131,8 +130,6 @@ const ListView = ({ content }) => {
         return;
       }
 
-      const auth = getAuth();
-      const user = auth.currentUser;
       if (!user) {
         throw new Error("User not authenticated");
       }
@@ -266,6 +263,7 @@ const ListView = ({ content }) => {
                 }
                 setSelectedItems(newSelected);
               }}
+              userRole={userData?.role}
             />
           ))}
         </div>

--- a/portal-app/src/components/TileItem.jsx
+++ b/portal-app/src/components/TileItem.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 
 const TileItem = ({
   id,
@@ -14,6 +13,7 @@ const TileItem = ({
   isSelected,
   onSelect,
   isLessonGenerator,
+  userRole,
 }) => {
   const handleDelete = (e) => {
     e.stopPropagation();
@@ -39,7 +39,7 @@ const TileItem = ({
       onClick={handleContentClick}
     >
       <div className="absolute top-2 right-2 flex gap-2">
-        {!isLessonGenerator && (
+        {!isLessonGenerator && userRole === "admin" && (
           <button
             onClick={handleDelete}
             className="text-gray-400 hover:text-red-500 transition-colors duration-200"
@@ -62,7 +62,7 @@ const TileItem = ({
           </button>
         )}
       </div>
-      {!isLessonGenerator && (
+      {!isLessonGenerator && userRole === "admin" && (
         <div className="absolute top-2 left-2" onClick={(e) => e.stopPropagation()}>
           <input
             type="checkbox"


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #168

## Description
- [ ] Remove the individual delete option on the nugget for non-admin user
- [ ] Remove the selection of multiple nuggets and having the option to delete it for non-admin user
- [ ] admin has all the access

## Type of Change
- [ ] New feature

## Checklist
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
Users do not have delete option:
![image](https://github.com/user-attachments/assets/a515910c-e802-4197-9b9b-160034aa1c87)
Admin has delete option:
![image](https://github.com/user-attachments/assets/3258110c-e9d8-445a-8805-0727def741ee)

