### PR TITLE
[Issue #151] Hide 'Open in New Tab' and 'Content URL:' option

### DIFF
--- a/portal-app/src/pages/view-content/index.jsx
+++ b/portal-app/src/pages/view-content/index.jsx
@@ -151,6 +151,24 @@ const ViewContent = () => {
                 </h2>
               </div>
 
+              {/* Show Content URL only for PDFs and external links, not for videos */}
+              {(!isVideoLink(fileUrl) && fileUrl) && (
+                <div className="mb-4 p-3 bg-gray-50 border rounded-lg">
+                  <div className="flex items-center justify-between">
+                    <span className="text-gray-600">Content URL:</span>
+                    <a
+                      href={fileUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:text-blue-800 underline flex items-center"
+                    >
+                      Open in New Tab
+                      <FaExternalLinkAlt className="ml-2 h-4 w-4" />
+                    </a>
+                  </div>
+                </div>
+              )}
+
               {isVideoLink(fileUrl) && (
                 <div className="mb-4">
                   <div className="border rounded-lg overflow-hidden">

--- a/portal-app/src/pages/view-content/index.jsx
+++ b/portal-app/src/pages/view-content/index.jsx
@@ -151,24 +151,6 @@ const ViewContent = () => {
                 </h2>
               </div>
 
-              {/* Add content link for PDFs and Videos */}
-              {(isVideoLink(fileUrl) || isPdfLink(fileUrl)) && (
-                <div className="mb-4 p-3 bg-gray-50 border rounded-lg">
-                  <div className="flex items-center justify-between">
-                    <span className="text-gray-600">Content URL:</span>
-                    <a
-                      href={fileUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 hover:text-blue-800 underline flex items-center"
-                    >
-                      Open in New Tab
-                      <FaExternalLinkAlt className="ml-2 h-4 w-4" />
-                    </a>
-                  </div>
-                </div>
-              )}
-
               {isVideoLink(fileUrl) && (
                 <div className="mb-4">
                   <div className="border rounded-lg overflow-hidden">


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #151 

## Description
- Removed both "Open in New Tab" and "Content URL:" from the View Content page

## Type of Change
- [ ] Bug fix
- [ X ] New feature
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ X ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
- ![Screenshot 2025-02-21 220556](https://github.com/user-attachments/assets/8afcce97-a036-4809-a0d5-f94456274abd)
- ![Screenshot 2025-02-21 220737](https://github.com/user-attachments/assets/708a8a32-744b-44e5-9039-52a6eaac4589)

## Additional Context
- Add any other context or information here.

