### PR TITLE
[Issue #216] Task/add delete section to lesson plan

### DIFF
--- a/portal-app/src/pages/edit_lesson/index.jsx
+++ b/portal-app/src/pages/edit_lesson/index.jsx
@@ -117,6 +117,15 @@ export const EditLesson = () => {
   const handleChange_objective = (value) => {
     setFormData({ ...formData, objectives: value });
   };
+  
+  const deleteSection = (index) => {
+    const updatedSections = sections.filter((_, i) => i !== index);
+    setSections(updatedSections);
+    setFormData((prevData) => ({
+      ...prevData,
+      sections: updatedSections,
+    }));
+  }; 
 
   const handleSectionChange = (index, value) => {
     const updatedSections = [...sections];
@@ -386,7 +395,15 @@ export const EditLesson = () => {
                 >
                   + Add materials from the portal
                 </button>
-
+                {sections.length > 1 && (
+                  <button
+                    type="button"
+                    className="absolute top-0 right-0 text-red-500 text-xl font-bold"
+                    onClick={() => deleteSection(index)}
+                  >
+                    &times;
+                  </button>
+                )}
                 <div className="flex flex-wrap mt-2">
                   {selectedMaterials[index]?.map((material) => (
                     <div

--- a/portal-app/src/pages/lesson_generator/index.jsx
+++ b/portal-app/src/pages/lesson_generator/index.jsx
@@ -78,6 +78,15 @@ export const LessonGenerator = () => {
     setFormData({ ...formData, sections: updatedSections });
   };
 
+  const deleteSection = (index) => {
+    const updatedSections = sections.filter((_, i) => i !== index);
+    setSections(updatedSections);
+    setFormData((prevData) => ({
+      ...prevData,
+      sections: updatedSections,
+    }));
+  };  
+
   const addSection = () => {
     setSections([...sections, { intro: "", contentIds: [] }]);
   };
@@ -407,7 +416,16 @@ export const LessonGenerator = () => {
                 >
                   + Create New Nugget
                 </button>
-
+                
+                {sections.length > 1 && (
+                  <button
+                    type="button"
+                    className="bg-red-500 text-white py-1 px-3 rounded"
+                    onClick={() => deleteSection(index)}
+                  >
+                  Delete Section
+                  </button>
+                )}
                 <div className="flex flex-wrap mt-2">
                   {selectedMaterials[index]?.map((material) => (
                     <div

--- a/portal-app/src/pages/lesson_generator/index.jsx
+++ b/portal-app/src/pages/lesson_generator/index.jsx
@@ -79,13 +79,28 @@ export const LessonGenerator = () => {
   };
 
   const deleteSection = (index) => {
+    // Remove the section at the given index
     const updatedSections = sections.filter((_, i) => i !== index);
+  
+    // Update selectedMaterials by shifting keys
+    const updatedMaterials = Object.keys(selectedMaterials)
+      .map((key) => parseInt(key, 10))
+      .filter((key) => key !== index)
+      .reduce((acc, key) => {
+        const newKey = key > index ? key - 1 : key;
+        acc[newKey] = selectedMaterials[key];
+        return acc;
+      }, {});
+  
     setSections(updatedSections);
+    setSelectedMaterials(updatedMaterials);
+    
     setFormData((prevData) => ({
       ...prevData,
       sections: updatedSections,
     }));
-  };  
+  };
+  
 
   const addSection = () => {
     setSections([...sections, { intro: "", contentIds: [] }]);

--- a/portal-app/src/pages/lesson_generator/index.jsx
+++ b/portal-app/src/pages/lesson_generator/index.jsx
@@ -420,10 +420,10 @@ export const LessonGenerator = () => {
                 {sections.length > 1 && (
                   <button
                     type="button"
-                    className="bg-red-500 text-white py-1 px-3 rounded"
+                    className="absolute top-0 right-0 text-red-500 text-xl font-bold"
                     onClick={() => deleteSection(index)}
                   >
-                  Delete Section
+                    &times;
                   </button>
                 )}
                 <div className="flex flex-wrap mt-2">


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #216 

## Description
- Added X icon to allow users to remove sections in the Lesson Generator and Edit Lesson.
- Ensured users cannot delete the last remaining section to prevent empty lesson structures.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ X ] Other (please specify): Task

## Checklist
- [ X ] My code follows the style guidelines of this project.
- [ X ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
- ![Screenshot 2025-03-06 175245](https://github.com/user-attachments/assets/ff166bd0-d689-4442-af13-a50beb4be113)
- ![Screenshot 2025-03-06 182859](https://github.com/user-attachments/assets/3a6d8b27-a957-4476-aa2f-eda2f22a9e1f)
