### PR TITLE
[Issue #219] move the upgrade popup to homepage

### DIFF
--- a/portal-app/src/components/HomePage.jsx
+++ b/portal-app/src/components/HomePage.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import content_creator from "../assets/content_creator.png";
 import educator from "../assets/educator.png";
 import lesson_plans from "../assets/lesson_plans.png";
@@ -8,68 +8,93 @@ import useUserData from "../hooks/useUserData";
 const HomePage = ({ user }) => {
   const navigate = useNavigate();
   const { userData } = useUserData();
+  const [showUpgradePopup, setShowUpgradePopup] = useState(false);
+
   return (
-    <div className="text-center mt-1">
-      <div className="bg-gray-200 p-1 rounded-lg shadow-lg ">
-        <div className="flex justify-center space-x-10">
-          <div>
-            <img
-              src={educator}
-              alt="Educator Icon"
-              className="mx-auto max-w-xs w-40 h-40"
-            />
-            <p className="mt-4">
-              {user ? (
-                <button
-                  onClick={() => navigate("/lesson-generator")}
-                  className="font-bold py-2 px-4 rounded"
-                >
-                  Try our Lesson Plan Generator!
-                </button>
-              ) : (
-                "Manage teaching materials & generate lesson plans"
-              )}
+    <>
+      {showUpgradePopup && (
+        <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50 z-50">
+          <div className="bg-white p-6 rounded-md shadow-lg max-w-md w-full">
+            <p className="text-lg font-bold text-red-500">
+              To access this feature, please upgrade to TeacherPlus by emailing{" "}
+              <a href="mailto:contact@diyaresearch.org" className="text-blue-600">
+                contact@diyaresearch.org
+              </a>
+              .
             </p>
+            <button
+              onClick={() => setShowUpgradePopup(false)}
+              className="mt-4 bg-gray-400 py-2 px-3 rounded"
+            >
+              Close
+            </button>
           </div>
-          {user && userData?.role === "admin" && (
+        </div>
+      )}
+      <div className="text-center mt-1">
+        <div className="bg-gray-200 p-1 rounded-lg shadow-lg ">
+          <div className="flex justify-center space-x-10">
+            <div>
+              <img src={educator} alt="Educator Icon" className="mx-auto max-w-xs w-40 h-40" />
+              <p className="mt-4">
+                {user ? (
+                  <button
+                    onClick={() => {
+                      if (userData.role === "teacherDefault") {
+                        setShowUpgradePopup(true);
+                      } else {
+                        navigate("/lesson-generator");
+                      }
+                    }}
+                    className="font-bold py-2 px-4 rounded"
+                  >
+                    Try our Lesson Plan Generator!
+                  </button>
+                ) : (
+                  "Manage teaching materials & generate lesson plans"
+                )}
+              </p>
+            </div>
+            {user && userData?.role === "admin" && (
+              <div>
+                <img
+                  src={content_creator}
+                  alt="Content Creator Icon"
+                  className="mx-auto max-w-xs w-40 h-40"
+                />
+                <p className="mt-4">
+                  <button
+                    onClick={() => navigate("/upload-content")}
+                    className="font-bold py-2 px-4 rounded"
+                  >
+                    Click here to upload educational contents
+                  </button>
+                </p>
+              </div>
+            )}
             <div>
               <img
-                src={content_creator}
-                alt="Content Creator Icon"
+                src={lesson_plans}
+                alt="Lesson Plans Icon"
                 className="mx-auto max-w-xs w-40 h-40"
               />
               <p className="mt-4">
-                <button
-                  onClick={() => navigate("/upload-content")}
-                  className="font-bold py-2 px-4 rounded"
-                >
-                  Click here to upload educational contents
-                </button>
+                {user ? (
+                  <button
+                    onClick={() => navigate("/my-plans")}
+                    className="font-bold py-2 px-4 rounded"
+                  >
+                    View Lesson Plans
+                  </button>
+                ) : (
+                  "View and manage your lesson plans"
+                )}
               </p>
             </div>
-          )}
-          <div>
-            <img
-              src={lesson_plans}
-              alt="Lesson Plans Icon"
-              className="mx-auto max-w-xs w-40 h-40"
-            />
-            <p className="mt-4">
-              {user ? (
-                <button
-                  onClick={() => navigate("/my-plans")}
-                  className="font-bold py-2 px-4 rounded"
-                >
-                  View Lesson Plans
-                </button>
-              ) : (
-                "View and manage your lesson plans"
-              )}
-            </p>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/portal-app/src/pages/lesson_generator/index.jsx
+++ b/portal-app/src/pages/lesson_generator/index.jsx
@@ -36,7 +36,6 @@ export const LessonGenerator = () => {
   const [showUploadModal, setShowUploadModal] = useState(false);
   const { userData } = useUserData(); // Get user data
   const userRole = userData?.role; // Extract role
-  const [showUpgradePopup, setShowUpgradePopup] = useState(false);
 
   useEffect(() => {
     axios
@@ -91,10 +90,7 @@ export const LessonGenerator = () => {
       return;
     }
 
-    if (userRole === "teacherDefault") {
-      console.log("Showing upgrade popup for teacherDefault");
-      setShowUpgradePopup(true);
-    } else if (userRole === "teacherPlus" || userRole === "admin") {
+    if (userRole === "teacherPlus" || userRole === "admin") {
       if (selectedSectionIndex === null) {
         setSelectedSectionIndex(0);
       }
@@ -519,26 +515,6 @@ export const LessonGenerator = () => {
           isPublic={false}
         />
       </Modal>
-      {/* Popup for Teacher Default Users */}
-      {showUpgradePopup && (
-        <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50">
-          <div className="bg-white p-6 rounded-md shadow-lg">
-            <p className="text-lg font-bold text-red-500">
-              To access this feature, please upgrade to TeacherPlus by emailing{" "}
-              <a href="mailto:contact@diyaresearch.org" className="text-blue-600">
-                contact@diyaresearch.org
-              </a>
-              .
-            </p>
-            <button
-              onClick={() => setShowUpgradePopup(false)}
-              className="mt-4 bg-gray-400 py-1 px-3 rounded"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Ticket Reference
- [x] Issue Number: Closes #219 

## Description
- [x] When default user click the lesson generator, show the upgrade popup in landing page

## Type of Change
- [x] New feature

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/8c1f8d7e-fd66-40c4-84ba-8a309dd4b0d4)

