### PR TITLE
[Issue #227] Feature/Add hyperlink to nugget title

### DIFF
--- a/portal-app/src/pages/lesson_generator/index.jsx
+++ b/portal-app/src/pages/lesson_generator/index.jsx
@@ -8,6 +8,7 @@ import UploadContent from "../upload-content/index";
 import useUserData from "../../hooks/useUserData";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css"; // Import Quill CSS
+import { FaExternalLinkAlt } from "react-icons/fa";
 
 Modal.setAppElement("#root");
 
@@ -535,7 +536,16 @@ export const LessonGenerator = () => {
                       key={material.id}
                       className="p-2 border rounded-md m-1 text-xs flex items-center"
                     >
-                      <span>{material.Title}</span>
+                      {/* Hyperlinked Title */}
+                      <a
+                        href={`/view-content/${material.UnitID}`} 
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:text-blue-800 underline flex items-center"
+                      >
+                        {material.Title} 
+                      </a>
+
                       <button
                         onClick={() => removeMaterial(material.id, index)}
                         className="ml-2 text-red-500 font-bold"


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #227 

## Description
- This PR implements the feature to hyperlink the nugget title in the Lesson Plan Generator.
- When a nugget is selected and added to a lesson plan, the title of the nugget will be clickable and will open the nugget's detailed view in a new tab.

## Type of Change
- [ ] Bug fix
- [ X ] New feature
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ X ] My code follows the style guidelines of this project.
- [ X ] I have performed a self-review of my code.
- [ X ] I have commented my code where necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
- ![Screenshot 2025-03-11 202717](https://github.com/user-attachments/assets/def70177-fd1a-4332-823b-ba095320bd47)