### PR TITLE
[Issue #169] Task/Added 'View' button above 'Select' for nuggets in lesson plan generator

### DIFF
--- a/portal-app/src/components/OverlayTileView.jsx
+++ b/portal-app/src/components/OverlayTileView.jsx
@@ -153,23 +153,35 @@ const OverlayTileView = ({ content, onClose, onSelectMaterial, initialSelectedTi
                       date={formatDate(item.LastModified)}
                       onClick={() => {}}
                     />
-                    <button
-                      onClick={() => {
-                        setSelectedTiles((prevState) =>
-                          prevState.includes(item.id)
-                            ? prevState.filter((id) => id !== item.id)
-                            : [...prevState, item.id]
-                        );
-                        onSelectMaterial(item);
-                      }}
-                      className={`absolute bottom-3 right-2 py-1 px-3 rounded ${
-                        selectedTiles.includes(item.id)
-                          ? "bg-red-500 text-white"
-                          : "bg-blue-500 text-white"
-                      }`}
-                    >
-                      {selectedTiles.includes(item.id) ? "Unselect" : "Select"}
-                    </button>
+                    <div className="absolute bottom-3 right-2 flex flex-col space-y-2">
+                      {/* View Button - Opens content in a new tab */}
+                      <a
+                        href={`/view-content/${item.UnitID}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="py-1 px-3 rounded bg-green-500 text-white hover:bg-green-700 transition duration-200 text-center"
+                      >
+                        View
+                      </a>
+
+                      <button
+                        onClick={() => {
+                          setSelectedTiles((prevState) =>
+                            prevState.includes(item.id)
+                              ? prevState.filter((id) => id !== item.id)
+                              : [...prevState, item.id]
+                          );
+                          onSelectMaterial(item);
+                        }}
+                        className={`py-1 px-3 rounded text-center ${
+                          selectedTiles.includes(item.id)
+                            ? "bg-red-500 text-white"
+                            : "bg-blue-500 text-white"
+                        }`}
+                      >
+                        {selectedTiles.includes(item.id) ? "Unselect" : "Select"}
+                      </button>
+                    </div>
                   </div>
                 ))}
             </div>


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #169 

## Description
- Added a "View" button above the "Select" button in the lesson plan generator.
- This allows users to preview nuggets before adding them to lesson plans.
- The "View" button opens the nugget in a new tab.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ X ] Other (please specify): Task 

## Checklist
- [ X ] My code follows the style guidelines of this project.
- [ X ] I have performed a self-review of my code.
- [ X ] I have commented my code where necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
- ![Screenshot 2025-03-13 180901](https://github.com/user-attachments/assets/6c27d2b3-19b8-4cdd-b0cb-dbaa01cef26c)