### PR TITLE
[Issue #254] Feature/Add delete module button for admin users

### DIFF
--- a/portal-app/src/pages/module_detail/index.jsx
+++ b/portal-app/src/pages/module_detail/index.jsx
@@ -213,6 +213,24 @@ const ModuleDetail = () => {
     }
   };
 
+  // Handle module deletion (admin only)
+  const handleDeleteModule = async () => {
+    if (!window.confirm("Are you sure you want to delete this module?")) return;
+  
+    try {
+      const token = localStorage.getItem("authToken");
+      await axios.delete(
+        `${process.env.REACT_APP_SERVER_ORIGIN_URL}/api/module/${moduleId}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+      navigate("/"); // Redirect to homepage
+    } catch (error) {
+      console.error("Error deleting module:", error);
+    }
+  };  
+
   return (
     <div className="flex justify-center items-center min-h-screen bg-blue-100">
       <div className="bg-white shadow-md rounded-lg px-8 py-6 w-full max-w-5xl">
@@ -397,12 +415,24 @@ const ModuleDetail = () => {
             </button>
           </>
         ) : (
-          <button
-            onClick={() => setMode("edit")}
-            className="bg-blue-500 text-white py-2 px-4 rounded"
-          >
-            Edit Module
-          </button>
+          <div className="flex gap-4">
+            <button
+              onClick={() => setMode("edit")}
+              className="bg-blue-500 text-white py-2 px-4 rounded"
+            >
+              Edit Module
+            </button>
+
+            {/* Show Delete button only to Admin */}
+            {userData?.role === "admin" && (
+              <button
+                onClick={handleDeleteModule}
+                className="bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600"
+              >
+                Delete Module
+              </button>
+            )}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #254 

## Description
- This PR adds a Delete Module button that is visible only to admin users.
- Admins can now delete modules directly from the module detail page.
- Button appears next to the "Edit Module" button in view mode.

## Type of Change
- [ ] Bug fix
- [ X ] New feature
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ X ] My code follows the style guidelines of this project.
- [ X ] I have performed a self-review of my code.
- [ X ] I have commented my code where necessary.
- [ X ] I have added tests that prove my fix is effective or my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
- ![Screenshot 2025-03-27 160755](https://github.com/user-attachments/assets/a1224c50-f349-4ca2-9cde-e40382a27f08)