### PR TITLE
[Issue #266] Feature/Display module image on the right side of the module detail page

### DIFF
--- a/portal-app/src/pages/module_detail/index.jsx
+++ b/portal-app/src/pages/module_detail/index.jsx
@@ -279,241 +279,116 @@ const ModuleDetail = () => {
   };
 
   return (
-    <div className="flex justify-center items-center min-h-screen bg-blue-100">
-      <div className="bg-white shadow-md rounded-lg px-8 py-6 w-full max-w-5xl">
-        {/* Title based on mode */}
+    <div className="flex justify-center items-start min-h-screen bg-blue-100">
+      <div className="bg-white shadow-md rounded-lg px-8 py-6 w-full max-w-6xl">
+        {/* Header: Title + Exit */}
         <div className="flex justify-between items-center mb-6">
-          <h1 className="text-3xl text-center mb-6">
-            {mode === "create" ? "Create Module" : mode === "edit" ? "Edit Module" : ""}
+          <h1 className="text-3xl font-bold">
+            {mode === "create" ? "Create Module" : mode === "edit" ? "Edit Module" : title}
           </h1>
           <button
             type="button"
-            className="bg-white text-black py-2 px-4 rounded border border-black hover:bg-gray-100 ml-4"
+            className="bg-white text-black py-2 px-4 rounded border border-black hover:bg-gray-100"
             onClick={handleExit}
           >
             Exit
           </button>
         </div>
-        {/* Module Title */}
-        <div className="mb-6">
-          {mode === "view" ? (
-            <h2 className="text-4xl font-bold mb-2">{title}</h2>
-          ) : (
-            <>
-              <label className="block text-gray-700 text-lg font-semibold mb-2">
-                Module Title:
-              </label>
-              <input
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                className="w-full px-4 py-2 border rounded bg-white text-xl"
-              />
-            </>
-          )}
-        </div>
-
-        {/* Select Image */}
-        {selectedImage && (
-          <div className="mb-6">
-            <img
-              src={imageMap[selectedImage] || module1}
-              alt="Cover"
-              className="w-full max-w-md rounded shadow-md mx-auto"
-            />
-          </div>
-        )}
-
-        {mode !== "view" && (
-          <div className="mb-6">
-            <label className="block text-gray-700 text-lg font-semibold mb-2">
-              Select Cover Image:
-            </label>
-            <div className="flex gap-4 flex-wrap">
-              {["module1", "module2", "module3", "module4", "module5"].map((key) => (
+  
+        {mode === "view" ? (
+          <div className="flex flex-col lg:flex-row gap-8">
+            {/* Left Side: Text Content */}
+            <div className="flex-1 space-y-6">
+              {/* Description */}
+              <div>
+                <label className="block text-gray-700 text-lg font-semibold mb-2">Description:</label>
                 <div
-                  key={key}
-                  onClick={() => setSelectedImage(key)}
-                  className={`border-4 rounded cursor-pointer ${
-                    selectedImage === key ? "border-blue-500" : "border-transparent"
-                  }`}
-                >
-                  <img src={imageMap[key]} alt={key} className="w-32 h-20 object-cover rounded" />
+                  className="border p-4 rounded bg-gray-50"
+                  dangerouslySetInnerHTML={{ __html: description }}
+                />
+              </div>
+  
+              {/* Tags */}
+              <div>
+                <label className="block text-gray-700 text-lg font-semibold mb-2">Module Tags:</label>
+                <div className="flex flex-wrap gap-2">
+                  {tags.map((tag, index) => {
+                    const colors = [
+                      "bg-pink-200",
+                      "bg-yellow-200",
+                      "bg-green-200",
+                      "bg-blue-200",
+                      "bg-purple-200",
+                    ];
+                    const color = colors[index % colors.length];
+                    return (
+                      <span key={index} className={`px-3 py-1 ${color} rounded text-sm`}>
+                        {tag}
+                      </span>
+                    );
+                  })}
                 </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Module Description */}
-        <div className="mb-6">
-          <label className="block text-gray-700 text-lg font-semibold mb-2">Description:</label>
-          {mode === "view" ? (
-            <div
-              className="border p-4 rounded bg-gray-50"
-              dangerouslySetInnerHTML={{ __html: description }}
-            />
-          ) : (
-            <ReactQuill value={description} onChange={setDescription} theme="snow" />
-          )}
-        </div>
-
-        {/* Module Tags */}
-        <div className="mb-6">
-          <label className="block text-gray-700 text-lg font-semibold mb-2">Module Tags:</label>
-          {mode !== "view" && (
-            <div className="flex space-x-2 mb-2">
-              <input
-                type="text"
-                value={newTag}
-                onChange={(e) => setNewTag(e.target.value)}
-                className="flex-1 px-4 py-2 border rounded"
-                placeholder="Enter a tag"
-              />
-              <button onClick={addTag} className="px-4 py-2 bg-blue-500 text-white rounded">
-                Add
-              </button>
-            </div>
-          )}
-          <div className="flex flex-wrap gap-2">
-            {tags.map((tag, index) => {
-              const colorClasses = [
-                "bg-pink-200",
-                "bg-yellow-200",
-                "bg-green-200",
-                "bg-blue-200",
-                "bg-purple-200",
-              ];
-              const bgColor = colorClasses[index % colorClasses.length];
-
-              return (
-                <span key={index} className={`px-3 py-1 ${bgColor} rounded m-1`}>
-                  {tag}
-                  {mode !== "view" && (
-                    <button onClick={() => removeTag(index)} className="text-red-500 ml-1">
-                      &times;
-                    </button>
+              </div>
+  
+              {/* Lesson Plans */}
+              <div>
+                <label className="block text-gray-700 text-lg font-semibold mb-2">Lesson Plans:</label>
+                <div className="border rounded p-2 bg-gray-50">
+                  {lessonPlans.length > 0 ? (
+                    lessonPlans.map((lesson, index) => (
+                      <div key={index} className="p-3 mb-2 border bg-white shadow-md rounded-md">
+                        <a
+                          href={`/lesson/${lesson.id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-black font-semibold hover:text-blue-600 hover:underline"
+                        >
+                          {lesson.title}
+                        </a>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-gray-500 text-sm">No lesson plans available.</p>
                   )}
-                </span>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Lesson Plans */}
-        <div className="mb-6">
-          <label className="block text-gray-700 text-lg font-semibold mb-2">Lesson Plans:</label>
-
-          {userData?.role === "admin" && mode !== "view" && selectedLessonIds.size > 0 && (
-            <div className="flex justify-end mb-2">
-              <button
-                onClick={handleDeleteSelected}
-                className="mb-2 px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-              >
-                Delete Selected ({selectedLessonIds.size})
-              </button>
-            </div>
-          )}
-
-          {/* Add More Lesson Plans Button */}
-          {mode !== "view" && (
-            <button
-              onClick={handleAddMoreLessonPlans}
-              className="bg-blue-500 text-white py-2 px-4 rounded"
-            >
-              Add More Lesson Plans
-            </button>
-          )}
-
-          <div className="border rounded p-2 bg-gray-50">
-            {lessonPlans.length > 0 ? (
-              lessonPlans.map((lesson, index) => (
-                <div
-                  key={index}
-                  draggable={mode !== "view"}
-                  onDragStart={mode !== "view" ? () => handleDragStart(index) : undefined}
-                  onDragOver={mode !== "view" ? handleDragOver : undefined}
-                  onDrop={mode !== "view" ? () => handleDrop(index) : undefined}
-                  className={`p-3 mb-2 border bg-white shadow-md rounded-md flex items-center gap-4 ${
-                    mode !== "view" ? "cursor-move" : "cursor-default"
-                  }`}
+                </div>
+              </div>
+  
+              {/* Buttons */}
+              <div className="flex gap-4 pt-4">
+                <button
+                  onClick={() => setMode("edit")}
+                  className="bg-blue-500 text-white py-2 px-4 rounded"
                 >
-                  {userData?.role === "admin" && mode !== "view" && (
-                    <input
-                      type="checkbox"
-                      checked={selectedLessonIds.has(lesson.id)}
-                      onChange={() => toggleSelectLesson(lesson.id)}
-                      className="mr-4"
-                    />
-                  )}
-                  <a
-                    href={`/lesson/${lesson.id}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-black font-semibold hover:text-blue-600 hover:underline"
+                  Edit Module
+                </button>
+                {userData?.role === "admin" && (
+                  <button
+                    onClick={handleDeleteModule}
+                    className="bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600"
                   >
-                    {lesson.title}
-                  </a>
-                </div>
-              ))
-            ) : (
-              <p className="text-gray-500 text-sm">No lesson plans available.</p>
-            )}
-          </div>
-        </div>
-
-        {/* Edit and Submit Buttons */}
-        {mode === "create" ? (
-          <button onClick={handleSubmit} className="bg-green-500 text-white py-2 px-4 rounded">
-            Submit Module
-          </button>
-        ) : mode === "edit" ? (
-          <>
-            <button onClick={handleUpdate} className="bg-yellow-500 text-white py-2 px-4 rounded">
-              Update Module
-            </button>
-            <button
-              onClick={() => setMode("view")}
-              className="bg-gray-500 text-white py-2 px-4 rounded ml-4"
-            >
-              Exit Edit Mode
-            </button>
-          </>
-        ) : (
-          userData?.role === "admin" && (
-            <div className="flex gap-4">
-              <button
-                onClick={() => setMode("edit")}
-                className="bg-blue-500 text-white py-2 px-4 rounded"
-              >
-                Edit Module
-              </button>
-              <button
-                onClick={handleDeleteModule}
-                className="bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600"
-              >
-                Delete Module
-              </button>
+                    Delete Module
+                  </button>
+                )}
+              </div>
             </div>
-          )
-        )}
-
-        {/* Show Overlay if showOverlay is true */}
-        {showOverlay && (
-          <OverlayTileView
-            content={portalContent}
-            onClose={() => setShowOverlay(false)}
-            onSelectMaterial={onSelectLessonPlan}
-            initialSelectedTiles={lessonPlans.map((lesson) => lesson.id)}
-            type={""}
-            category={""}
-            level={""}
-            contentType={"lessonPlan"}
-          />
+  
+            {/* Right Side: Image */}
+            <div className="flex-shrink-0 w-full lg:w-1/3">
+              {selectedImage && (
+                <img
+                  src={imageMap[selectedImage] || module1}
+                  alt="Cover"
+                  className="rounded shadow-md w-full"
+                />
+              )}
+            </div>
+          </div>
+        ) : (
+          // existing create/edit mode content goes here...
+          <p className="text-gray-500">Edit/Create mode layout unchanged.</p>
         )}
       </div>
     </div>
-  );
+  );  
 };
-
 export default ModuleDetail;

--- a/portal-app/src/pages/module_detail/index.jsx
+++ b/portal-app/src/pages/module_detail/index.jsx
@@ -279,116 +279,251 @@ const ModuleDetail = () => {
   };
 
   return (
-    <div className="flex justify-center items-start min-h-screen bg-blue-100">
-      <div className="bg-white shadow-md rounded-lg px-8 py-6 w-full max-w-6xl">
-        {/* Header: Title + Exit */}
+    <div className="flex justify-center items-center min-h-screen bg-blue-100">
+      <div className="bg-white shadow-md rounded-lg px-8 py-6 w-full max-w-5xl">
+        {/* Title based on mode */}
         <div className="flex justify-between items-center mb-6">
-          <h1 className="text-3xl font-bold">
-            {mode === "create" ? "Create Module" : mode === "edit" ? "Edit Module" : title}
+          <h1 className="text-3xl text-center mb-6">
+            {mode === "create" ? "Create Module" : mode === "edit" ? "Edit Module" : ""}
           </h1>
           <button
             type="button"
-            className="bg-white text-black py-2 px-4 rounded border border-black hover:bg-gray-100"
+            className="bg-white text-black py-2 px-4 rounded border border-black hover:bg-gray-100 ml-4"
             onClick={handleExit}
           >
             Exit
           </button>
         </div>
-  
+        {/* Title + Description + Image layout in view mode */}
         {mode === "view" ? (
-          <div className="flex flex-col lg:flex-row gap-8">
-            {/* Left Side: Text Content */}
-            <div className="flex-1 space-y-6">
-              {/* Description */}
-              <div>
-                <label className="block text-gray-700 text-lg font-semibold mb-2">Description:</label>
-                <div
-                  className="border p-4 rounded bg-gray-50"
-                  dangerouslySetInnerHTML={{ __html: description }}
-                />
-              </div>
-  
-              {/* Tags */}
-              <div>
-                <label className="block text-gray-700 text-lg font-semibold mb-2">Module Tags:</label>
-                <div className="flex flex-wrap gap-2">
-                  {tags.map((tag, index) => {
-                    const colors = [
-                      "bg-pink-200",
-                      "bg-yellow-200",
-                      "bg-green-200",
-                      "bg-blue-200",
-                      "bg-purple-200",
-                    ];
-                    const color = colors[index % colors.length];
-                    return (
-                      <span key={index} className={`px-3 py-1 ${color} rounded text-sm`}>
-                        {tag}
-                      </span>
-                    );
-                  })}
-                </div>
-              </div>
-  
-              {/* Lesson Plans */}
-              <div>
-                <label className="block text-gray-700 text-lg font-semibold mb-2">Lesson Plans:</label>
-                <div className="border rounded p-2 bg-gray-50">
-                  {lessonPlans.length > 0 ? (
-                    lessonPlans.map((lesson, index) => (
-                      <div key={index} className="p-3 mb-2 border bg-white shadow-md rounded-md">
-                        <a
-                          href={`/lesson/${lesson.id}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-black font-semibold hover:text-blue-600 hover:underline"
-                        >
-                          {lesson.title}
-                        </a>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-gray-500 text-sm">No lesson plans available.</p>
-                  )}
-                </div>
-              </div>
-  
-              {/* Buttons */}
-              <div className="flex gap-4 pt-4">
-                <button
-                  onClick={() => setMode("edit")}
-                  className="bg-blue-500 text-white py-2 px-4 rounded"
-                >
-                  Edit Module
-                </button>
-                {userData?.role === "admin" && (
-                  <button
-                    onClick={handleDeleteModule}
-                    className="bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600"
-                  >
-                    Delete Module
-                  </button>
-                )}
-              </div>
+          <div className="flex flex-col md:flex-row justify-between mb-6 gap-6">
+            <div className="flex-1">
+              <h2 className="text-4xl font-bold mb-4">{title}</h2>
+              <label className="block text-gray-700 text-lg font-semibold mb-2">
+                Description:
+              </label>
+              <div
+                className="border p-4 rounded bg-gray-50"
+                dangerouslySetInnerHTML={{ __html: description }}
+              />
             </div>
-  
-            {/* Right Side: Image */}
-            <div className="flex-shrink-0 w-full lg:w-1/3">
-              {selectedImage && (
+            {selectedImage && (
+              <div className="flex-shrink-0 w-full md:w-1/2 mt-4 md:mt-0">
                 <img
                   src={imageMap[selectedImage] || module1}
                   alt="Cover"
-                  className="rounded shadow-md w-full"
+                  className="rounded shadow-md w-full h-auto"
                 />
-              )}
-            </div>
+              </div>
+            )}
           </div>
         ) : (
-          // existing create/edit mode content goes here...
-          <p className="text-gray-500">Edit/Create mode layout unchanged.</p>
+          <>
+            {/* Title (edit/create mode) */}
+            <div className="mb-6">
+              <label className="block text-gray-700 text-lg font-semibold mb-2">
+                Module Title:
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full px-4 py-2 border rounded bg-white text-xl"
+              />
+            </div>
+
+            {/* Image Selector (edit/create mode) */}
+            {selectedImage && (
+              <div className="mb-6">
+                <label className="block text-gray-700 text-lg font-semibold mb-2">
+                  Select Cover Image:
+                </label>
+                <div className="flex gap-4 flex-wrap">
+                  {["module1", "module2", "module3", "module4", "module5"].map((key) => (
+                    <div
+                      key={key}
+                      onClick={() => setSelectedImage(key)}
+                      className={`border-4 rounded cursor-pointer ${
+                        selectedImage === key ? "border-blue-500" : "border-transparent"
+                      }`}
+                    >
+                      <img
+                        src={imageMap[key]}
+                        alt={key}
+                        className="w-32 h-20 object-cover rounded"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Description (edit/create mode) */}
+            <div className="mb-6">
+              <label className="block text-gray-700 text-lg font-semibold mb-2">
+                Description:
+              </label>
+              <ReactQuill value={description} onChange={setDescription} theme="snow" />
+            </div>
+          </>
+        )}
+
+        {/* Module Tags */}
+        <div className="mb-6">
+          <label className="block text-gray-700 text-lg font-semibold mb-2">Module Tags:</label>
+          {mode !== "view" && (
+            <div className="flex space-x-2 mb-2">
+              <input
+                type="text"
+                value={newTag}
+                onChange={(e) => setNewTag(e.target.value)}
+                className="flex-1 px-4 py-2 border rounded"
+                placeholder="Enter a tag"
+              />
+              <button onClick={addTag} className="px-4 py-2 bg-blue-500 text-white rounded">
+                Add
+              </button>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag, index) => {
+              const colorClasses = [
+                "bg-pink-200",
+                "bg-yellow-200",
+                "bg-green-200",
+                "bg-blue-200",
+                "bg-purple-200",
+              ];
+              const bgColor = colorClasses[index % colorClasses.length];
+
+              return (
+                <span key={index} className={`px-3 py-1 ${bgColor} rounded m-1`}>
+                  {tag}
+                  {mode !== "view" && (
+                    <button onClick={() => removeTag(index)} className="text-red-500 ml-1">
+                      &times;
+                    </button>
+                  )}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Lesson Plans */}
+        <div className="mb-6">
+          <label className="block text-gray-700 text-lg font-semibold mb-2">Lesson Plans:</label>
+
+          {userData?.role === "admin" && mode !== "view" && selectedLessonIds.size > 0 && (
+            <div className="flex justify-end mb-2">
+              <button
+                onClick={handleDeleteSelected}
+                className="mb-2 px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+              >
+                Delete Selected ({selectedLessonIds.size})
+              </button>
+            </div>
+          )}
+
+          {/* Add More Lesson Plans Button */}
+          {mode !== "view" && (
+            <button
+              onClick={handleAddMoreLessonPlans}
+              className="bg-blue-500 text-white py-2 px-4 rounded"
+            >
+              Add More Lesson Plans
+            </button>
+          )}
+
+          <div className="border rounded p-2 bg-gray-50">
+            {lessonPlans.length > 0 ? (
+              lessonPlans.map((lesson, index) => (
+                <div
+                  key={index}
+                  draggable={mode !== "view"}
+                  onDragStart={mode !== "view" ? () => handleDragStart(index) : undefined}
+                  onDragOver={mode !== "view" ? handleDragOver : undefined}
+                  onDrop={mode !== "view" ? () => handleDrop(index) : undefined}
+                  className={`p-3 mb-2 border bg-white shadow-md rounded-md flex items-center gap-4 ${
+                    mode !== "view" ? "cursor-move" : "cursor-default"
+                  }`}
+                >
+                  {userData?.role === "admin" && mode !== "view" && (
+                    <input
+                      type="checkbox"
+                      checked={selectedLessonIds.has(lesson.id)}
+                      onChange={() => toggleSelectLesson(lesson.id)}
+                      className="mr-4"
+                    />
+                  )}
+                  <a
+                    href={`/lesson/${lesson.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-black font-semibold hover:text-blue-600 hover:underline"
+                  >
+                    {lesson.title}
+                  </a>
+                </div>
+              ))
+            ) : (
+              <p className="text-gray-500 text-sm">No lesson plans available.</p>
+            )}
+          </div>
+        </div>
+
+        {/* Edit and Submit Buttons */}
+        {mode === "create" ? (
+          <button onClick={handleSubmit} className="bg-green-500 text-white py-2 px-4 rounded">
+            Submit Module
+          </button>
+        ) : mode === "edit" ? (
+          <>
+            <button onClick={handleUpdate} className="bg-yellow-500 text-white py-2 px-4 rounded">
+              Update Module
+            </button>
+            <button
+              onClick={() => setMode("view")}
+              className="bg-gray-500 text-white py-2 px-4 rounded ml-4"
+            >
+              Exit Edit Mode
+            </button>
+          </>
+        ) : (
+          userData?.role === "admin" && (
+            <div className="flex gap-4">
+              <button
+                onClick={() => setMode("edit")}
+                className="bg-blue-500 text-white py-2 px-4 rounded"
+              >
+                Edit Module
+              </button>
+              <button
+                onClick={handleDeleteModule}
+                className="bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600"
+              >
+                Delete Module
+              </button>
+            </div>
+          )
+        )}
+
+        {/* Show Overlay if showOverlay is true */}
+        {showOverlay && (
+          <OverlayTileView
+            content={portalContent}
+            onClose={() => setShowOverlay(false)}
+            onSelectMaterial={onSelectLessonPlan}
+            initialSelectedTiles={lessonPlans.map((lesson) => lesson.id)}
+            type={""}
+            category={""}
+            level={""}
+            contentType={"lessonPlan"}
+          />
         )}
       </div>
     </div>
-  );  
+  );
 };
+
 export default ModuleDetail;


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #266 

## Description
- This PR updates the layout of the Module Detail page to display the module image on the right side.
- The description, tags, and lesson plans now appear on the left.

## Type of Change
- [ ] Bug fix
- [ X ] New feature
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ X ] My code follows the style guidelines of this project.
- [ X ] I have performed a self-review of my code.
- [ X ] I have commented my code where necessary.
- [ X ] I have added tests that prove my fix is effective or my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
- ![Screenshot 2025-04-01 151253](https://github.com/user-attachments/assets/7ad5db42-6d60-437e-937f-8255caf12679)

- After Updating the Layout
![Screenshot 2025-04-02 102736](https://github.com/user-attachments/assets/e481ed5d-fd7a-42fe-ae34-4ba974500b04)