### PR TITLE
[Issue #126] Fix/Removed unused comment section from overlay to fix portal-app warnings

### DIFF
--- a/portal-app/src/components/Overlay.jsx
+++ b/portal-app/src/components/Overlay.jsx
@@ -84,17 +84,6 @@ const Overlay = ({ content, onClose }) => {
             {/* Ensure long URLs wrap */}
           </div>
         </div>
-        <div className="mt-4 p-2 border rounded">
-          <h3 className="text-lg">Add your comment here:</h3>
-          <br />
-          <textarea
-            className="w-full p-2 border rounded"
-            placeholder="Write a comment..."
-          ></textarea>
-          <div className="flex justify-end">
-            <button className="mt-2 p-2 bg-blue-500 text-white rounded">Comment</button>
-          </div>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Ticket Reference
- [ ] Issue Number: Closes #126 

## Description
- Removed the unused comment section from the content overlay component as it is not being used.

## Type of Change
- [ X ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ X ] My code follows the style guidelines of this project.
- [ X ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ X ] I have added tests that prove my fix is effective or my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
- ![Screenshot 2025-04-03 151516](https://github.com/user-attachments/assets/128baab7-5319-4779-a358-bcc502078a48)