### PR TITLE
[Issue #265] Make all/public/private plan dropdown for admin

### DIFF
--- a/server/controllers/lessonsController.js
+++ b/server/controllers/lessonsController.js
@@ -32,6 +32,27 @@ const getAllLessons = async (req, res) => {
   }
 };
 
+// Get all lessons for admin
+const getAllLessonsAdmin = async (req, res) => {
+  try {
+    const lessonsSnapshot = await db.collection(TABLE_LESSON).get();
+    if (lessonsSnapshot.empty) {
+      res.status(200).json([]);
+      return;
+    }
+    const lessons = [];
+    lessonsSnapshot.forEach((doc) => {
+      const lessonData = doc.data();
+      lessons.push({ id: doc.id, ...lessonData });
+    });
+    res.status(200).json(lessons);
+  } catch (error) {
+    console.error("Error fetching lessons:", error);
+    res.status(500).send(error.message);
+  }
+};
+
+
 const getLessonById = async (req, res) => {
   const lessonId = req.params.lessonId;
 
@@ -278,6 +299,7 @@ const downloadPDF = async (req, res) => {
 
 module.exports = {
   getAllLessons,
+  getAllLessonsAdmin,
   getLessonById,
   getUserLessons,
   postLesson,

--- a/server/routes/lessons.js
+++ b/server/routes/lessons.js
@@ -1,6 +1,7 @@
 const express = require("express");
 
 const { getAllLessons } = require("../controllers/lessonsController");
+const { getAllLessonsAdmin } = require("../controllers/lessonsController");
 const { getLessonById } = require("../controllers/lessonsController");
 const { getUserLessons } = require("../controllers/lessonsController");
 const { postLesson } = require("../controllers/lessonsController");
@@ -13,6 +14,7 @@ const router = express.Router();
 router.use(express.json());
 
 router.get("/lessons", getAllLessons);
+router.get("/lessons/admin", getAllLessonsAdmin);
 router.get("/lesson/myLessons", authenticateUser, getUserLessons);
 router.get("/lesson/:lessonId", getLessonById);
 router.get("/lessons/:lessonId/download", downloadPDF);


### PR DESCRIPTION
## Ticket Reference
- [x] Issue Number: Closes #265 

## Description
Update the system to allow admins to view three types of plans:

**- All Plans (public and private)**
**- Public Plans**
**- Private Plans**

The dropdown for admins should include all three options, while non-admin users will see only "Public Plans" and "My Plans".

## Type of Change
- [x] New feature

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d9bb5be5-6934-465b-85c3-31668db0a0d3)
![image](https://github.com/user-attachments/assets/9fda20ff-8407-4b49-8308-8533c90462ae)
![image](https://github.com/user-attachments/assets/a55aaecb-bdeb-4f0e-a885-836c6aebb439)


