### PR TITLE
Fix TypeError during teacher signup - Issue #384

### DIFF
--- a/portal-app/src/components/ExploreModulesSection.jsx
+++ b/portal-app/src/components/ExploreModulesSection.jsx
@@ -18,8 +18,8 @@ import { useNavigate } from "react-router-dom";
 // Add this function near the top of your file, after the imports
 const getItemImage = (item) => {
   const itemType = item._type;
-  const category = (item.category || item.Category || "").toLowerCase();
-  const level = (item.level || item.Level || "").toLowerCase();
+  const category = String(item.category || item.Category || "").toLowerCase();
+  const level = String(item.level || item.Level || "").toLowerCase();
 
   // Return images based on type and category
   if (itemType === "Module") {
@@ -76,7 +76,7 @@ const LockIcon = ({ isLocked }) => (
 
 // Add this helper function near the top of your file, outside the ExploreModulesSection component:
 function capitalizeWords(str) {
-  return (str || "")
+  return String(str || "")
     .toLowerCase()
     .replace(/\b\w/g, c => c.toUpperCase());
 }
@@ -1171,14 +1171,14 @@ const ExploreModulesSection = () => {
     // Filter by category if not "All"
     if (category !== "All") {
       items = items.filter(item =>
-        ((item.category || item.Category || "").toLowerCase() === category.toLowerCase())
+        (String(item.category || item.Category || "").toLowerCase() === category.toLowerCase())
       );
     }
 
     // Filter by level if not "All"
     if (level !== "All") {
       items = items.filter(item =>
-        ((item.level || item.Level || "").toLowerCase() === level.toLowerCase())
+        (String(item.level || item.Level || "").toLowerCase() === level.toLowerCase())
       );
     }
 
@@ -1186,7 +1186,7 @@ const ExploreModulesSection = () => {
     if (keyword.trim()) {
       const kw = keyword.trim().toLowerCase();
       items = items.filter(item =>
-        (item.title || item.Title || "").toLowerCase().includes(kw)
+        String(item.title || item.Title || "").toLowerCase().includes(kw)
       );
     }
 


### PR DESCRIPTION
## Summary
Fixes the TypeError that occurs during teacher account signup process.

## Problem
When users attempt to sign up for a teacher account, they encounter a JavaScript TypeError:
```
(item.category || item.Category || "").toLowerCase is not a function
```

This error occurs in the `ExploreModulesSection` component when the `getItemImage` function attempts to call `.toLowerCase()` on values that may not be strings.

## Root Cause
Some items in the Firestore database contain `category`, `Category`, `level`, `Level`, or `title` fields with non-string values (numbers, objects, null, etc.). When JavaScript tries to call `.toLowerCase()` on these non-string values, it throws a TypeError.

## Solution
Added `String()` wrapper around all values before calling `.toLowerCase()` to ensure safe string conversion:
- Fixed `getItemImage` function for category and level processing
- Fixed filtering logic for category, level, and title searches  
- Fixed `capitalizeWords` helper function

## Changes Made
- `portal-app/src/components/ExploreModulesSection.jsx`: Added `String()` conversion in 6 locations
- Ensures all data types are safely converted to strings before string methods are called

## Testing
- Tested the signup flow with the problematic email address
- Verified no more TypeError during teacher account creation
- Confirmed filtering and search functionality still works correctly

Closes #384

🤖 Generated with [Claude Code](https://claude.ai/code)